### PR TITLE
max-executors fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ usage: spark-submit --deploy-mode client --class com.amazonaws.emr.SparkLogsAnal
 
 For easier access, there is a public jar file available at S3.  For example, for version 0.2.0-SNAPSHOT, the file path to jar file is `s3://awslabs-code-us-east-1/EMRAdvisor/aws-emr-insights-assembly-0.2.0-SNAPSHOT.jar`.
 
-To run with `spark-submit`,  include the jar file as below (version 0.2.0-SNAPSHOT as an example)
+To run with `spark-submit`,  include the application jar file as below (version 0.2.0-SNAPSHOT as an example)
 ```
---jars s3://awslabs-code-us-east-1/EMRAdvisor/aws-emr-insights-assembly-0.2.0-SNAPSHOT.jar
+s3://awslabs-code-us-east-1/EMRAdvisor/aws-emr-insights-assembly-0.2.0-SNAPSHOT.jar
 ```
 The jar file can also be downloaded at `https://awslabs-code-us-east-1.s3.amazonaws.com/EMRAdvisor/aws-emr-insights-assembly-0.2.0-SNAPSHOT.jar`.
 

--- a/src/main/scala/com/amazonaws/emr/SparkLogsAnalyzer.scala
+++ b/src/main/scala/com/amazonaws/emr/SparkLogsAnalyzer.scala
@@ -3,6 +3,7 @@ package com.amazonaws.emr
 import com.amazonaws.emr.report.HtmlReport
 import com.amazonaws.emr.spark.EmrSparkLogParser
 import com.amazonaws.emr.utils.Constants._
+import com.amazonaws.emr.utils.Formatter.normalizeName
 
 import scala.annotation.tailrec
 import scala.sys.exit
@@ -24,7 +25,7 @@ object SparkLogsAnalyzer extends App {
     list match {
       case Nil => map
       case x :: value :: tail if x.startsWith("--") =>
-        if (optParams.exists(_.option == x)) parseArgs(map ++ Map(x.replaceAll("-", "") -> value), tail)
+        if (optParams.exists(_.option == x)) parseArgs(map ++ Map(normalizeName(x) -> value), tail)
         else {
           println(usage)
           println("Error: Unknown option " + x)

--- a/src/main/scala/com/amazonaws/emr/spark/analyzer/AppEnvCostAnalyzer.scala
+++ b/src/main/scala/com/amazonaws/emr/spark/analyzer/AppEnvCostAnalyzer.scala
@@ -248,7 +248,9 @@ class AppEnvCostAnalyzer extends AppAnalyzer with Logging {
           ArchitectureType.ARM64,
           ContainerRequest(1, driverNode.cpu, driverNode.memory, freeStorage),
           ContainerRequest(executorsNum, executorNode.cpu, executorNode.memory, executorsTotalStorage / executorsNum),
-          totalCostsArm))
+          totalCostsArm,
+          executorNode.cpu/sparkRuntimeConfigs.executorCores
+        ))
       else
         Some(EmrServerlessEnv(
           totalCores,
@@ -257,7 +259,9 @@ class AppEnvCostAnalyzer extends AppAnalyzer with Logging {
           ArchitectureType.X86_64,
           ContainerRequest(1, driverNode.cpu, driverNode.memory, freeStorage),
           ContainerRequest(executorsNum, executorNode.cpu, executorNode.memory, executorsTotalStorage / executorsNum),
-          totalCostsX86))
+          totalCostsX86,
+          executorNode.cpu/sparkRuntimeConfigs.executorCores
+        ))
 
     }
 

--- a/src/main/scala/com/amazonaws/emr/spark/analyzer/AppOptimizerAnalyzer.scala
+++ b/src/main/scala/com/amazonaws/emr/spark/analyzer/AppOptimizerAnalyzer.scala
@@ -13,6 +13,7 @@ import com.amazonaws.emr.utils.Constants.ParamExecutors
 import com.amazonaws.emr.utils.Formatter.asGB
 import com.amazonaws.emr.utils.Formatter.byteStringAsBytes
 import com.amazonaws.emr.utils.Formatter.humanReadableBytes
+import com.amazonaws.emr.utils.Formatter.normalizeName
 import com.amazonaws.emr.utils.Formatter.roundUp
 import org.apache.spark.internal.Logging
 
@@ -50,7 +51,8 @@ class AppOptimizerAnalyzer extends AppAnalyzer with Logging {
       appContext.appSparkExecutors.executorsMaxRunning)
     appContext.appRecommendations.currentSparkConf = Some(currentConf)
 
-    val maxExecutors: Int = Try(options(ParamExecutors.name).toInt).getOrElse(Config.ExecutorsMaxTestsCount)
+    val maxExecutors: Int = Try(options(normalizeName(ParamExecutors.name)).toInt)
+                              .getOrElse(Config.ExecutorsMaxTestsCount)
     val expectedDuration: Option[Long] = Try(Duration(options(ParamDuration.name)).toMillis).toOption
 
     val coresList = getOptimalCoresPerExecutor(appContext)

--- a/src/main/scala/com/amazonaws/emr/utils/Formatter.scala
+++ b/src/main/scala/com/amazonaws/emr/utils/Formatter.scala
@@ -132,5 +132,9 @@ object Formatter {
     val gigabyte = megabyte * 1024
     bytes.toDouble / gigabyte
   }
+  
+  def normalizeName(name: String): String = {
+    name.replaceAll("-", "")
+  }
 
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
1. fix not getting --max-executors values
2. Due to Serverless work node size limit (https://docs.aws.amazon.com/emr/latest/EMR-Serverless-UserGuide/app-behavior.html#worker-configs), we may need to use bigger workers for higher memory, in this case spark.task.cpus can be larger than 1  (For example, executor 1core, 19G,  we may need to give a worker with 4vCPUs and set task.cpu=4)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
