### PR TITLE
fix when spark.hadoop.aws.region not available

### DIFF
--- a/src/main/scala/com/amazonaws/emr/spark/analyzer/AppEnvCostAnalyzer.scala
+++ b/src/main/scala/com/amazonaws/emr/spark/analyzer/AppEnvCostAnalyzer.scala
@@ -11,6 +11,7 @@ import com.amazonaws.emr.spark.models.runtime.Environment._
 import com.amazonaws.emr.spark.models.AppContext
 import com.amazonaws.emr.spark.models.OptimalTypes._
 import com.amazonaws.emr.spark.models.runtime.SparkRuntime.getMemoryWithOverhead
+import com.amazonaws.emr.utils.Constants.DefaultRegion
 import com.amazonaws.emr.utils.Constants.{ParamSpot, ParamRegion}
 import org.apache.spark.internal.Logging
 
@@ -24,7 +25,7 @@ class AppEnvCostAnalyzer extends AppAnalyzer with Logging {
     val spotDiscount: Double = options.getOrElse(ParamSpot.name, "0.0").toDouble
 
     // check for specific regions to compute costs
-    val awsRegion = options.getOrElse(ParamRegion.name, "us-east-1")
+    val awsRegion = options.getOrElse(ParamRegion.name, DefaultRegion)
     logInfo(s"Computing costs for $awsRegion region")
 
     // get instances with corresponding price

--- a/src/main/scala/com/amazonaws/emr/spark/analyzer/AppRuntimeAnalyzer.scala
+++ b/src/main/scala/com/amazonaws/emr/spark/analyzer/AppRuntimeAnalyzer.scala
@@ -4,6 +4,8 @@ import com.amazonaws.emr.utils.Constants.NotAvailable
 import com.amazonaws.emr.api.AwsEmr
 import com.amazonaws.emr.spark.models.AppContext
 import com.amazonaws.emr.spark.models.runtime._
+import com.amazonaws.emr.utils.Constants.DefaultRegion
+import com.amazonaws.emr.utils.Constants.ParamRegion
 import com.amazonaws.services.costandusagereport.model.AWSRegion
 import org.apache.spark.internal.Logging
 import org.apache.spark.utils.SparkHelper.parseSparkCmd
@@ -60,7 +62,8 @@ class AppRuntimeAnalyzer extends AppAnalyzer with Logging {
 
       val appName = appContext.appConfigs.sparkConfigs.getOrElse("spark.app.name", NotAvailable)
       val jobRunId = appContext.appConfigs.sparkConfigs.getOrElse("spark.app.id", NotAvailable)
-      val region = appContext.appConfigs.sparkConfigs.getOrElse("spark.hadoop.aws.region", NotAvailable)
+      val region = appContext.appConfigs.sparkConfigs.getOrElse("spark.hadoop.aws.region",
+        options.getOrElse(ParamRegion.name, DefaultRegion))
       val application = AwsEmr.findServerlessApplicationByJobRun(appName, jobRunId, Region.of(region))
 
       EmrServerlessRun(jobRunId, sparkVersion, application)

--- a/src/main/scala/com/amazonaws/emr/utils/Constants.scala
+++ b/src/main/scala/com/amazonaws/emr/utils/Constants.scala
@@ -1,10 +1,13 @@
 package com.amazonaws.emr.utils
 
 import com.amazonaws.emr.report.HtmlReport.htmlBold
+import software.amazon.awssdk.regions.Region
 
 object Constants {
 
   val NotAvailable = "Not Available"
+  
+  val DefaultRegion = Region.US_EAST_1.toString
 
   // Documentation Link
   val LinkEmrOnEc2Documentation = "https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-what-is-emr.html"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
AppRuntimeAnalyzer uses regions from input parameters or default region when spark.hadoop.aws.region is not available.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
